### PR TITLE
Fix local time vs UTC discrepancy in init.

### DIFF
--- a/src/datepickr.js
+++ b/src/datepickr.js
@@ -437,6 +437,9 @@ datepickr.init = function (element, instanceConfig) {
             self.currentMonthView = date.current.month.integer();
             self.currentDayView = date.current.day();
         }
+        
+        var currentTimestamp = new Date(self.currentYearView, self.currentMonthView, self.selectedDate.day).getTime();
+        self.element.value = formatDate(self.config.dateFormat, currentTimestamp);
 
         wrap();
         buildCalendar();


### PR DESCRIPTION
Upon initialization, datepickr to- and from-dates are off by one day if calendar day of local user's system differs from calendar day of UTC (GMT). This PR fixes that. 

Hat-tip to: https://github.com/nikkilocke